### PR TITLE
feat: Add table of contents (TOC) command for EPUB files

### DIFF
--- a/cli/commands/read.py
+++ b/cli/commands/read.py
@@ -1,6 +1,6 @@
 import typer
 from cli.src.epub3 import Epub3
-from cli.src.utils import success, error, task
+from cli.src.utils import success, error, task, warning
 
 class Read:
     def __init__(self):
@@ -25,6 +25,24 @@ class Read:
                 metadata = self.epub3.get_opf_metadata_info()
                 for key, value in metadata.items():
                     task(f"{key.title()}: {value}")
+            except ValueError as e:
+                error(f"{e}")
+                raise typer.Exit(1)
+
+        @self.cli.command()
+        def toc():
+            """List the table of contents of the EPUB file"""
+            try:
+                toc_items = self.epub3.get_toc()
+                if not toc_items:
+                    warning("No table of contents found")
+                    return
+                
+                task("Table of Contents:")
+                for item in toc_items:
+                    # Indent based on level
+                    indent = "  " * item["level"]
+                    task(f"{indent}• {item['label']} ({item['content']})")
             except ValueError as e:
                 error(f"{e}")
                 raise typer.Exit(1)

--- a/cli/src/xml.py
+++ b/cli/src/xml.py
@@ -44,3 +44,7 @@ class Xml:
     def save(self):
         """Write the tree to a file"""
         self.tree.write(self.file_path, pretty_print=True, xml_declaration=True, encoding="utf-8")
+
+    def get_nodes(self, xpath_expr: str) -> list[_Element]:
+        """Return a list of nodes matching the given XPath expression."""
+        return self.root.xpath(xpath_expr, namespaces=self.NAMESPACES)


### PR DESCRIPTION
- Implement `read toc` command to display EPUB table of contents
- Add `get_toc()` method in Epub3 class to extract TOC from toc.xhtml
- Support parsing TOC using lxml with XHTML and EPUB namespaces
- Add unit tests for TOC command with success, empty, and failure scenarios