### PR TITLE
fix: Add delete command to remove files from EPUB workspace

### DIFF
--- a/cli/commands/delete.py
+++ b/cli/commands/delete.py
@@ -1,0 +1,29 @@
+import typer
+import os
+import shutil
+from cli.src.epub3 import Epub3
+from cli.src.utils import success, error
+
+class Delete:
+    def __init__(self):
+        self.cli = typer.Typer()
+        self.epub3 = Epub3()
+
+        @self.cli.command()
+        def file(target_file: str = typer.Argument(..., help="The target file or chapter in the EPUB workspace to delete")):
+            """Delete a chapter or file from the EPUB workspace."""
+            target_path = os.path.join(self.epub3.workspace, target_file)
+            if not os.path.exists(target_path):
+                error(f"Target file/directory '{target_file}' not found in EPUB workspace '{self.epub3.workspace}'.")
+                raise typer.Exit(1)
+
+            try:
+                if os.path.isdir(target_path):
+                    shutil.rmtree(target_path)
+                    success(f"Deleted directory: {target_file}")
+                else:
+                    os.remove(target_path)
+                    success(f"Deleted file: {target_file}")
+            except Exception as e:
+                error(f"Error deleting file/directory '{target_file}': {e}")
+                raise typer.Exit(1) 

--- a/cli/main.py
+++ b/cli/main.py
@@ -2,6 +2,7 @@ import typer
 from cli.commands.edit import Edit
 from cli.commands.setup import Setup
 from cli.commands.read import Read
+from cli.commands.delete import Delete
 
 class EpubCLI:
     def __init__(self):
@@ -9,6 +10,7 @@ class EpubCLI:
         self.edit_commands = Edit()
         self.setup_commands= Setup()
         self.read_commands = Read()
+        self.delete_commands = Delete()
         self._register_commands()
 
     def _register_commands(self):
@@ -20,6 +22,7 @@ class EpubCLI:
         # Register nested commands
         self.cli.add_typer(self.edit_commands.cli, name="edit", help="Edit the EPUB file")
         self.cli.add_typer(self.read_commands.cli, name="read", help="Read the EPUB file")
+        self.cli.add_typer(self.delete_commands.cli, name="delete", help="Delete files from the EPUB workspace")
 
     def run(self):
         self.cli()


### PR DESCRIPTION
- Implement `delete file` command to remove files or directories
- Add support for deleting chapters and other files in the EPUB workspace
- Include error handling and user feedback for deletion operations